### PR TITLE
Error response

### DIFF
--- a/lib/poros/carbonfootprint.rb
+++ b/lib/poros/carbonfootprint.rb
@@ -6,8 +6,14 @@ class Carbonfootprint
               :total
 
   def initialize(data)
-    @equivalent_carbon_in_kg = data['equivalent_carbon_in_kg']
-    @currency = data['cost']['currency']
-    @total = data['cost']['total'].to_f
+    if data['equivalent_carbon_in_kg'].nil?
+      @equivalent_carbon_in_kg = nil
+      @currency = nil
+      @total = nil
+    else
+      @equivalent_carbon_in_kg = data['equivalent_carbon_in_kg']
+      @currency = data['cost']['currency']
+      @total = data['cost']['total'].to_f
+    end
   end
 end

--- a/spec/fixtures/vcr_cassettes/cloverly_error_footprint_request.yml
+++ b/spec/fixtures/vcr_cassettes/cloverly_error_footprint_request.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cloverly.com/2019-03-beta/estimates/vehicle
+    body:
+      encoding: UTF-8
+      string: '{"distance":{"value":"10000000","units":"miles"},"fuel_efficiency":{"value":"25","units":"mpg","of":"gasoline"}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer public_key:<CLOVERY_PUBLIC_KEY>
+      User-Agent:
+      - Faraday v1.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 12 Jan 2021 22:40:45 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d8f9949cc4d707c87bb797fd4ebb719291610491245; expires=Thu, 11-Feb-21
+        22:40:45 GMT; path=/; domain=.cloverly.com; HttpOnly; SameSite=Lax; Secure
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Vary:
+      - Origin
+      Via:
+      - 1.1 vegur
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '079a5b4b030000c508f2bc8000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=CRw2b%2BLA75cBHPAgqXrXrN4FJNPCcGCvh6%2FjnNA37Vs2u4SWZQS4EzdyeXiNDAQ69smbR4LbHC0yZ0fF49kUVGhe%2FUMaZVSrNHn6Vd814b3yYP4LRnSmLL0MNJiG"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 610a618b3f4ec508-ORD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":"Cloverly does not have the necessary offset are available
+        to fulfill the request."}'
+  recorded_at: Tue, 12 Jan 2021 22:40:45 GMT
+recorded_with: VCR 6.0.0

--- a/spec/poros/Carbonfootprint_spec.rb
+++ b/spec/poros/Carbonfootprint_spec.rb
@@ -24,4 +24,15 @@ RSpec.describe 'Carbonfootprint poro' do
     expect(carbon_footprint.currency).to eq(response_data['cost']['currency'])
     expect(carbon_footprint.total).to eq(response_data['cost']['total'].to_f)
   end
+
+  it 'Makes an empty object with a cloverly error' do
+    response_data = {
+      "error": "Cloverly does not have the necessary offset are available to fulfill the request."
+    }
+    carbon_footprint = Carbonfootprint.new(response_data)
+
+    expect(carbon_footprint.equivalent_carbon_in_kg).to be nil
+    expect(carbon_footprint.currency).to be nil
+    expect(carbon_footprint.total).to be nil
+  end
 end

--- a/spec/requests/api/v1/carbonfootprint_request_spec.rb
+++ b/spec/requests/api/v1/carbonfootprint_request_spec.rb
@@ -4,20 +4,32 @@ RSpec.describe 'Cloverly Microservice API' do
   it 'can return car footprint data' do
     VCR.use_cassette('cloverly_vehicle_footprint_request') do
       get '/api/v1/carbonfootprint?fuel_efficiency=25&trip_distance=55&fuel_type=gasoline'
+
+      expect(last_response).to be_successful
+
+      data = JSON.parse(last_response.body, symbolize_names: true)[:data]
+
+      expect(data).to have_key(:equivalent_carbon_in_kg)
+      expect(data).to have_key(:cloverly_offset_cost)
+      expect(data[:cloverly_offset_cost]).to have_key(:currency)
+      expect(data[:cloverly_offset_cost]).to have_key(:total)
+
+      expect(data[:equivalent_carbon_in_kg]).to eq(19.555)
+      expect(data[:cloverly_offset_cost]).to be_an(Hash)
+      expect(data[:cloverly_offset_cost][:currency]).to eq('USD')
+      expect(data[:cloverly_offset_cost][:total]).to eq(0.28)
     end
+  end
 
-    expect(last_response).to be_successful
+  it 'will return null data if cloverly sends an error response' do
+    VCR.use_cassette('cloverly_error_footprint_request') do
+      get '/api/v1/carbonfootprint?fuel_efficiency=25&trip_distance=10000000&fuel_type=gasoline'
 
-    data = JSON.parse(last_response.body, symbolize_names: true)[:data]
+      data = JSON.parse(last_response.body, symbolize_names: true)[:data]
 
-    expect(data).to have_key(:equivalent_carbon_in_kg)
-    expect(data).to have_key(:cloverly_offset_cost)
-    expect(data[:cloverly_offset_cost]).to have_key(:currency)
-    expect(data[:cloverly_offset_cost]).to have_key(:total)
-
-    expect(data[:equivalent_carbon_in_kg]).to eq(19.555)
-    expect(data[:cloverly_offset_cost]).to be_an(Hash)
-    expect(data[:cloverly_offset_cost][:currency]).to eq('USD')
-    expect(data[:cloverly_offset_cost][:total]).to eq(0.28)
+      expect(data[:equivalent_carbon_in_kg]).to be nil
+      expect(data[:cloverly_offset_cost][:currency]).to be nil
+      expect(data[:cloverly_offset_cost][:total]).to be nil
+    end
   end
 end


### PR DESCRIPTION
Addresses the edge case of the Cloverly API returning an error, rather than the expected response.

## Description
<!--- Describe your changes in detail -->
This PR changes how the microservice handles receiving an error from the Cloverly API. In the case that the microservice receives an error, it will now generate an "empty" Footprint object, with all attributes being nil, and send nil  data to the back end.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before this change, the microservice would return an HTML response to the backend if Cloverly returned an error. In changing this response to null, JSON footprint attributes, the back end can handle the missing data with it's normal, model level validation when creating a Footprint in the database.
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This has been tested at the poro and request level with mocked Cloverly response data.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This should prevent Footprint creation from breaking in the back end when Cloverly does not return valid footprint data.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the README to reflect any changes.
